### PR TITLE
feat: add Instagram double-tap/double-click to like on post media

### DIFF
--- a/software/DICE/DICE/C_Feed.html
+++ b/software/DICE/DICE/C_Feed.html
@@ -15,6 +15,7 @@
     <script src="{{ static 'js/dwell.js' }}"></script>
     <script src="{{ static 'js/rowheights.js' }}"></script>
     <script src="{{ static 'js/insta_feed.js' }}"></script>
+    <script src="{{ static 'js/insta_double_tap_like.js' }}"></script>
     {{ elif subsession.FEED == "DICE/T_Feed_Generic.html" }}
     <script src="{{ static 'js/swipes.js' }}"></script>
     {{ else }}

--- a/software/DICE/DICE/T_Item_Insta.html
+++ b/software/DICE/DICE/T_Item_Insta.html
@@ -24,10 +24,12 @@
                 </div>
 
                 <!-- Post Image -->
-                <div class="promoted-content spons-post position-relative">
-                    <a href="{{i.target}}" target="_blank" style="text-decoration: none; cursor: pointer;">
-                        <img src="{{i.media}}" class="w-100 img-fluid mt-2" style="object-fit: cover;" alt="{{i.alt_text}}">
-                    </a>
+                <div class="insta-post-media position-relative mt-2">
+                    <div class="promoted-content spons-post">
+                        <a href="{{i.target}}" target="_blank" style="text-decoration: none; cursor: pointer;">
+                            <img src="{{i.media}}" class="w-100 img-fluid" style="object-fit: cover;" alt="{{i.alt_text}}">
+                        </a>
+                    </div>
                 </div>
 
                 <!-- CTA Button -->
@@ -108,7 +110,9 @@
                 </div>
 
                 <!-- Post Image -->
-                <img src="{{i.media}}" class="w-100 img-fluid mt-2" style="object-fit: cover;" alt="{{i.alt_text}}">
+                <div class="insta-post-media position-relative mt-2">
+                    <img src="{{i.media}}" class="w-100 img-fluid" style="object-fit: cover;" alt="{{i.alt_text}}">
+                </div>
 
                 <!-- Post Actions -->
                 <div class="p-2">

--- a/software/DICE/DICE/static/css/preloader_insta.css
+++ b/software/DICE/DICE/static/css/preloader_insta.css
@@ -99,3 +99,65 @@
     right: 0;
     border: 2px solid white;
 }
+
+/* Double-tap like overlay on post media */
+.insta-post-media {
+    overflow: hidden;
+}
+
+.insta-double-tap-heart {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.insta-double-tap-heart-icon {
+    font-size: 96px;
+    line-height: 1;
+    color: #ffffff;
+    opacity: 0;
+    transform: scale(0);
+    filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.6)) drop-shadow(0 4px 20px rgba(0, 0, 0, 0.45));
+    will-change: transform, opacity;
+}
+
+.insta-double-tap-heart.is-visible .insta-double-tap-heart-icon {
+    animation: insta-heart-pop 1s ease-out forwards;
+}
+
+@keyframes insta-heart-pop {
+    0% {
+        opacity: 0;
+        transform: scale(0);
+    }
+    12% {
+        opacity: 1;
+        transform: scale(1.25);
+    }
+    24% {
+        transform: scale(0.95);
+    }
+    36% {
+        transform: scale(1);
+    }
+    70% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .insta-double-tap-heart.is-visible .insta-double-tap-heart-icon {
+        animation: none;
+        opacity: 1;
+        transform: scale(1);
+    }
+}

--- a/software/DICE/DICE/static/js/insta_double_tap_like.js
+++ b/software/DICE/DICE/static/js/insta_double_tap_like.js
@@ -1,0 +1,88 @@
+console.log("Instagram double-tap like ready!");
+
+document.addEventListener('DOMContentLoaded', function () {
+    var DOUBLE_TAP_MS = 300;
+    var TAP_MOVE_THRESHOLD_PX = 20;
+    var OVERLAY_DURATION_MS = 1000;
+
+    var lastTapByMedia = new WeakMap();
+
+    function showHeartOverlay(mediaElement) {
+        var overlay = mediaElement.querySelector('.insta-double-tap-heart');
+        if (!overlay) {
+            overlay = document.createElement('span');
+            overlay.className = 'insta-double-tap-heart';
+            overlay.setAttribute('aria-hidden', 'true');
+            overlay.innerHTML = '<i class="bi bi-heart-fill insta-double-tap-heart-icon"></i>';
+            mediaElement.appendChild(overlay);
+        }
+
+        var heartIcon = overlay.querySelector('.insta-double-tap-heart-icon');
+        overlay.classList.remove('is-visible');
+        if (heartIcon) {
+            heartIcon.style.animation = 'none';
+            void heartIcon.offsetWidth;
+            heartIcon.style.animation = '';
+        }
+        void overlay.offsetWidth;
+        overlay.classList.add('is-visible');
+
+        window.setTimeout(function () {
+            overlay.classList.remove('is-visible');
+        }, OVERLAY_DURATION_MS);
+    }
+
+    function handleDoubleLike(mediaElement, event) {
+        var instaPost = mediaElement.closest('.insta-post');
+        if (!instaPost) {
+            return;
+        }
+
+        if (event) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        if (typeof window.diceLikeInstaPostMedia === 'function') {
+            window.diceLikeInstaPostMedia(instaPost);
+        }
+
+        showHeartOverlay(mediaElement);
+    }
+
+    function registerDoubleTap(mediaElement) {
+        mediaElement.addEventListener('dblclick', function (event) {
+            handleDoubleLike(mediaElement, event);
+        });
+
+        mediaElement.addEventListener('touchend', function (event) {
+            if (event.changedTouches.length !== 1) {
+                return;
+            }
+
+            var touch = event.changedTouches[0];
+            var lastTap = lastTapByMedia.get(mediaElement);
+            var now = Date.now();
+
+            if (lastTap) {
+                var timeDelta = now - lastTap.time;
+                var moveX = Math.abs(touch.clientX - lastTap.x);
+                var moveY = Math.abs(touch.clientY - lastTap.y);
+
+                if (timeDelta <= DOUBLE_TAP_MS && moveX <= TAP_MOVE_THRESHOLD_PX && moveY <= TAP_MOVE_THRESHOLD_PX) {
+                    handleDoubleLike(mediaElement, event);
+                    lastTapByMedia.delete(mediaElement);
+                    return;
+                }
+            }
+
+            lastTapByMedia.set(mediaElement, {
+                time: now,
+                x: touch.clientX,
+                y: touch.clientY
+            });
+        });
+    }
+
+    document.querySelectorAll('.insta-post .insta-post-media').forEach(registerDoubleTap);
+});

--- a/software/DICE/DICE/static/js/like_button.js
+++ b/software/DICE/DICE/static/js/like_button.js
@@ -3,7 +3,8 @@ console.log("Reactions (likes, replies, and promoted content clicks) ready!");
 document.addEventListener('DOMContentLoaded', function() {
     console.log("Document is ready!");
 
-    function toggleLike(button) {
+    function toggleLike(button, options) {
+        options = options || {};
         const icon = button.querySelector('.like-icon');
         const likeCountSpan = button.querySelector('.like-count');
         let originalText = likeCountSpan.textContent;
@@ -12,6 +13,13 @@ document.addEventListener('DOMContentLoaded', function() {
         // Detect icon type: heart (Twitter/Instagram) or thumbs-up (LinkedIn)
         let isHeart = icon.classList.contains('bi-heart') || icon.classList.contains('bi-heart-fill');
         let isThumbs = icon.classList.contains('bi-hand-thumbs-up') || icon.classList.contains('bi-hand-thumbs-up-fill');
+
+        if (options.onlyLike) {
+            let alreadyLiked = icon.classList.contains('bi-heart-fill') || icon.classList.contains('bi-hand-thumbs-up-fill');
+            if (alreadyLiked) {
+                return false;
+            }
+        }
 
         if (isHeart) {
             if (icon.classList.contains('bi-heart')) {
@@ -60,7 +68,20 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         console.log("Like toggled for button:", button.id, "; New count:", newText);
+        return true;
     }
+
+    window.diceApplyLike = function (likeButton, options) {
+        return toggleLike(likeButton, options);
+    };
+
+    window.diceLikeInstaPostMedia = function (instaPost) {
+        const likeButton = instaPost.querySelector('.like-button');
+        if (!likeButton) {
+            return false;
+        }
+        return toggleLike(likeButton, { onlyLike: true });
+    };
 
     document.querySelectorAll('.like-button').forEach(button => {
         button.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
  - Add double-tap (touch) and double-click (mouse) on Instagram post images to like a post, matching real Instagram
  interaction patterns.
  - Double-tap is like-only (does not unlike if already liked); the heart button still toggles normally.
  - Show a brief centered heart overlay animation on the post image when liking via double interaction.
  - Reuse existing like tracking so `#likes_data` submission stays unchanged.
  ## Changes
  - **`like_button.js`**: add `onlyLike` option to `toggleLike` and expose `diceLikeInstaPostMedia` helper.
  - **`insta_double_tap_like.js`** *(new)*: gesture detection and overlay animation for Instagram feed posts.
  - **`T_Item_Insta.html`**: wrap post media in `.insta-post-media` containers.
  - **`preloader_insta.css`**: heart pop/fade animation styles.
  - **`C_Feed.html`**: load the new script on the Instagram feed only.
  ## Test plan
  - [ ] Open the Instagram feed and double-click a regular post image → heart overlay appears, icon fills red, count
  increments once.
  - [ ] Double-click the same post again → overlay still shows, count does not decrement.
  - [ ] Click the heart button → still toggles like/unlike normally.
  - [ ] On mobile or touch emulation, double-tap the image → same behavior as double-click.
  - [ ] On a sponsored post, single tap still tracks promoted clicks; double-tap likes without navigating away.
  - [ ] Submit the feed → `#likes_data` includes posts liked via both the heart button and double interaction.