### PR TITLE
feat: add repost interaction tracking across feed platforms.

### DIFF
--- a/software/DICE/DICE/C_Feed.html
+++ b/software/DICE/DICE/C_Feed.html
@@ -7,6 +7,7 @@
     <script src="{{ static 'js/gradients.js' }}"></script>
     <script src="{{ static 'js/mobile.js' }}"></script>
     <script src="{{ static 'js/like_button.js' }}"></script>
+    <script src="{{ static 'js/repost_button.js' }}"></script>
     <script src="{{ static 'js/interactions.js' }}"></script>
     <script src="{{ static 'js/scrolling.js' }}"></script>
     {{ if subsession.FEED == "DICE/T_Feed_Stories.html" }}

--- a/software/DICE/DICE/C_Feed.html
+++ b/software/DICE/DICE/C_Feed.html
@@ -15,6 +15,7 @@
     <script src="{{ static 'js/dwell.js' }}"></script>
     <script src="{{ static 'js/rowheights.js' }}"></script>
     <script src="{{ static 'js/insta_feed.js' }}"></script>
+    <script src="{{ static 'js/insta_double_tap_like.js' }}"></script>
     {{ elif subsession.FEED == "DICE/T_Feed_Generic.html" }}
     <script src="{{ static 'js/swipes.js' }}"></script>
     {{ else }}

--- a/software/DICE/DICE/C_Feed.html
+++ b/software/DICE/DICE/C_Feed.html
@@ -16,6 +16,7 @@
     <script src="{{ static 'js/dwell.js' }}"></script>
     <script src="{{ static 'js/rowheights.js' }}"></script>
     <script src="{{ static 'js/insta_feed.js' }}"></script>
+    <script src="{{ static 'js/insta_double_tap_like.js' }}"></script>
     {{ elif subsession.FEED == "DICE/T_Feed_Generic.html" }}
     <script src="{{ static 'js/swipes.js' }}"></script>
     {{ else }}

--- a/software/DICE/DICE/T_Feed_Generic.html
+++ b/software/DICE/DICE/T_Feed_Generic.html
@@ -17,6 +17,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
     <input type="hidden" name="promoted_post_clicks" id="promoted_post_clicks" value="">

--- a/software/DICE/DICE/T_Feed_Insta.html
+++ b/software/DICE/DICE/T_Feed_Insta.html
@@ -8,6 +8,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
     <input type="hidden" id="screen_resolution" name="screen_resolution" value="">
@@ -111,6 +112,25 @@
 
 
 
+
+    <!-- First Repost Confirmation Modal -->
+    <div class="modal fade" id="firstRepostModal" tabindex="-1" aria-labelledby="firstRepostModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-body text-center py-4">
+                    <svg aria-label="Repost" role="img" viewBox="0 0 24 24" width="48" height="48" fill="currentColor" class="text-primary mb-3">
+                        <path d="M19.998 9.497a1 1 0 0 0-1 1v4.228a3.274 3.274 0 0 1-3.27 3.27h-5.313l1.791-1.787a1 1 0 0 0-1.412-1.416L7.29 18.287a1.004 1.004 0 0 0-.294.707v.001c0 .023.012.042.013.065a.923.923 0 0 0 .281.643l3.502 3.504a1 1 0 0 0 1.414-1.414l-1.797-1.798h5.318a5.276 5.276 0 0 0 5.27-5.27v-4.228a1 1 0 0 0-1-1Zm-6.41-3.496-1.795 1.795a1 1 0 1 0 1.414 1.414l3.5-3.5a1.003 1.003 0 0 0 0-1.417l-3.5-3.5a1 1 0 0 0-1.414 1.414l1.794 1.794H8.27A5.277 5.277 0 0 0 3 9.271V13.5a1 1 0 0 0 2 0V9.271a3.275 3.275 0 0 1 3.271-3.27Z"></path>
+                    </svg>
+                    <p class="fw-semibold mb-1">Reposted to your profile</p>
+                    <p class="text-muted small mb-0">Your followers can see this in their feed.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center pb-4">
+                    <button type="button" class="btn btn-outline-secondary rounded-pill px-4" id="firstRepostUndo" data-bs-dismiss="modal">Undo</button>
+                    <button type="button" class="btn btn-primary rounded-pill px-4" data-bs-dismiss="modal">OK</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- Post Modal (for creating new posts) -->
     <div class="modal fade" id="tweetModal" tabindex="-1" aria-labelledby="tweetModalLabel" aria-hidden="true">

--- a/software/DICE/DICE/T_Feed_Linkedin.html
+++ b/software/DICE/DICE/T_Feed_Linkedin.html
@@ -15,6 +15,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
     <input type="hidden" id="screen_resolution" name="screen_resolution" value="">

--- a/software/DICE/DICE/T_Feed_Mass_Media.html
+++ b/software/DICE/DICE/T_Feed_Mass_Media.html
@@ -15,6 +15,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
 

--- a/software/DICE/DICE/T_Feed_Stories.html
+++ b/software/DICE/DICE/T_Feed_Stories.html
@@ -13,6 +13,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
     <input type="hidden" name="promoted_post_clicks" id="promoted_post_clicks" value="">

--- a/software/DICE/DICE/T_Feed_Twitter.html
+++ b/software/DICE/DICE/T_Feed_Twitter.html
@@ -17,6 +17,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
     <input type="hidden" id="screen_resolution" name="screen_resolution" value="">

--- a/software/DICE/DICE/T_Feed_Twitter_Profile.html
+++ b/software/DICE/DICE/T_Feed_Twitter_Profile.html
@@ -15,6 +15,7 @@
 <input type="hidden" name="cta" id="cta" value="False">
 <input type="hidden" id="likes_data" name="likes_data">
 <input type="hidden" id="replies_data" name="replies_data">
+<input type="hidden" id="reposts_data" name="reposts_data">
 <input type="hidden" id="touch_capability" name="touch_capability" value="">
 <input type="hidden" id="device_type" name="device_type" value="">
 

--- a/software/DICE/DICE/T_Feed_Twitter_Replies.html
+++ b/software/DICE/DICE/T_Feed_Twitter_Replies.html
@@ -15,6 +15,7 @@
     <input type="hidden" name="cta" id="cta" value="False">
     <input type="hidden" id="likes_data" name="likes_data">
     <input type="hidden" id="replies_data" name="replies_data">
+    <input type="hidden" id="reposts_data" name="reposts_data">
     <input type="hidden" id="touch_capability" name="touch_capability" value="">
     <input type="hidden" id="device_type" name="device_type" value="">
 

--- a/software/DICE/DICE/T_Item_Generic.html
+++ b/software/DICE/DICE/T_Item_Generic.html
@@ -52,7 +52,7 @@
                                 <span class="bi bi-chat text-secondary reply-icon" id="reply_icon_{{i.doc_id}}" style="cursor: pointer">️</span>
                                 <span class="reply-count text-secondary" id="reply_count_{{i.doc_id}}">{{i.replies}}</span>
                             </div>
-                            <div class="repost-button col">
+                            <div class="repost-button col" id="repost_button_{{i.doc_id}}">
                                 <span class="bi bi-arrow-repeat text-secondary repost-icon" style="cursor: pointer">️</span>
                                 <span class="repost-count text-secondary">{{i.reposts}}</span>
                             </div>
@@ -119,7 +119,7 @@
                                 <span class="bi bi-chat text-secondary reply-icon" id="reply_icon_{{i.doc_id}}" style="cursor: pointer">️</span>
                                 <span class="reply-count text-secondary" id="reply_count_{{i.doc_id}}">{{i.replies}}</span>
                             </div>
-                            <div class="repost-button col">
+                            <div class="repost-button col" id="repost_button_{{i.doc_id}}">
                                 <span class="bi bi-arrow-repeat text-secondary repost-icon" style="cursor: pointer">️</span>
                                 <span class="repost-count text-secondary">{{i.reposts}}</span>
                             </div>

--- a/software/DICE/DICE/T_Item_Insta.html
+++ b/software/DICE/DICE/T_Item_Insta.html
@@ -55,10 +55,21 @@
                                 <span class="bi bi-chat reply-icon" id="reply_icon_{{i.doc_id}}" style="font-size: 24px; cursor: pointer;"></span>
                                 <span class="reply-count ms-1" id="reply_count_{{i.doc_id}}" style="font-size: 14px;">{{i.replies}}</span>
                             </div>
+                            <!-- Repost -->
+                            <div class="repost-button me-3 d-flex align-items-center" id="repost_button_{{i.doc_id}}" style="cursor: pointer;">
+                                <span class="repost-icon insta-repost-icon" style="width: 24px; height: 24px; cursor: pointer;">
+                                    <svg class="repost-icon-default" aria-label="Repost" role="img" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                                        <path d="M19.998 9.497a1 1 0 0 0-1 1v4.228a3.274 3.274 0 0 1-3.27 3.27h-5.313l1.791-1.787a1 1 0 0 0-1.412-1.416L7.29 18.287a1.004 1.004 0 0 0-.294.707v.001c0 .023.012.042.013.065a.923.923 0 0 0 .281.643l3.502 3.504a1 1 0 0 0 1.414-1.414l-1.797-1.798h5.318a5.276 5.276 0 0 0 5.27-5.27v-4.228a1 1 0 0 0-1-1Zm-6.41-3.496-1.795 1.795a1 1 0 1 0 1.414 1.414l3.5-3.5a1.003 1.003 0 0 0 0-1.417l-3.5-3.5a1 1 0 0 0-1.414 1.414l1.794 1.794H8.27A5.277 5.277 0 0 0 3 9.271V13.5a1 1 0 0 0 2 0V9.271a3.275 3.275 0 0 1 3.271-3.27Z"></path>
+                                    </svg>
+                                    <svg class="repost-icon-check d-none" aria-label="Reposted" role="img" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                                        <path d="M16 6.001a1 1 0 0 0 .924-1.382.998.998 0 0 0-.217-.326l-3.5-3.5a1 1 0 1 0-1.414 1.414l1.794 1.794H8.27A5.277 5.277 0 0 0 3 9.271V13.5a1 1 0 1 0 2 0V9.271a3.275 3.275 0 0 1 3.271-3.27h7.73Zm3.998 3.496a1 1 0 0 0-1 1v4.228a3.274 3.274 0 0 1-3.27 3.27H7.996a1.001 1.001 0 0 0-.706 1.708l3.502 3.504a.997.997 0 0 0 1.414 0 1 1 0 0 0 0-1.414l-1.797-1.798h5.317a5.276 5.276 0 0 0 5.271-5.27v-4.228a1 1 0 0 0-1-1Zm-5.205-.51-3.905 3.906-1.681-1.681a1 1 0 1 0-1.414 1.414l2.388 2.388a1 1 0 0 0 1.414 0l4.612-4.614a1 1 0 1 0-1.414-1.414Z"></path>
+                                    </svg>
+                                </span>
+                                <span class="repost-count ms-1" style="font-size: 14px;">{{i.reposts}}</span>
+                            </div>
                             <!-- Share -->
                             <div class="share-button d-flex align-items-center">
-                                <span class="bi bi-send" style="font-size: 24px; cursor: pointer;"></span>
-                                <span class="ms-1" style="font-size: 14px;">{{i.reposts}}</span>
+                                <span class="bi bi-send share-icon" style="font-size: 24px; cursor: pointer;"></span>
                             </div>
                         </div>
                         <!-- Bookmark -->
@@ -124,10 +135,21 @@
                                 <span class="bi bi-chat reply-icon" id="reply_icon_{{i.doc_id}}" style="font-size: 24px; cursor: pointer;"></span>
                                 <span class="reply-count ms-1" id="reply_count_{{i.doc_id}}" style="font-size: 14px;">{{i.replies}}</span>
                             </div>
+                            <!-- Repost -->
+                            <div class="repost-button me-3 d-flex align-items-center" id="repost_button_{{i.doc_id}}" style="cursor: pointer;">
+                                <span class="repost-icon insta-repost-icon" style="width: 24px; height: 24px; cursor: pointer;">
+                                    <svg class="repost-icon-default" aria-label="Repost" role="img" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                                        <path d="M19.998 9.497a1 1 0 0 0-1 1v4.228a3.274 3.274 0 0 1-3.27 3.27h-5.313l1.791-1.787a1 1 0 0 0-1.412-1.416L7.29 18.287a1.004 1.004 0 0 0-.294.707v.001c0 .023.012.042.013.065a.923.923 0 0 0 .281.643l3.502 3.504a1 1 0 0 0 1.414-1.414l-1.797-1.798h5.318a5.276 5.276 0 0 0 5.27-5.27v-4.228a1 1 0 0 0-1-1Zm-6.41-3.496-1.795 1.795a1 1 0 1 0 1.414 1.414l3.5-3.5a1.003 1.003 0 0 0 0-1.417l-3.5-3.5a1 1 0 0 0-1.414 1.414l1.794 1.794H8.27A5.277 5.277 0 0 0 3 9.271V13.5a1 1 0 0 0 2 0V9.271a3.275 3.275 0 0 1 3.271-3.27Z"></path>
+                                    </svg>
+                                    <svg class="repost-icon-check d-none" aria-label="Reposted" role="img" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                                        <path d="M16 6.001a1 1 0 0 0 .924-1.382.998.998 0 0 0-.217-.326l-3.5-3.5a1 1 0 1 0-1.414 1.414l1.794 1.794H8.27A5.277 5.277 0 0 0 3 9.271V13.5a1 1 0 1 0 2 0V9.271a3.275 3.275 0 0 1 3.271-3.27h7.73Zm3.998 3.496a1 1 0 0 0-1 1v4.228a3.274 3.274 0 0 1-3.27 3.27H7.996a1.001 1.001 0 0 0-.706 1.708l3.502 3.504a.997.997 0 0 0 1.414 0 1 1 0 0 0 0-1.414l-1.797-1.798h5.317a5.276 5.276 0 0 0 5.271-5.27v-4.228a1 1 0 0 0-1-1Zm-5.205-.51-3.905 3.906-1.681-1.681a1 1 0 1 0-1.414 1.414l2.388 2.388a1 1 0 0 0 1.414 0l4.612-4.614a1 1 0 1 0-1.414-1.414Z"></path>
+                                    </svg>
+                                </span>
+                                <span class="repost-count ms-1" style="font-size: 14px;">{{i.reposts}}</span>
+                            </div>
                             <!-- Share -->
                             <div class="share-button d-flex align-items-center">
-                                <span class="bi bi-send" style="font-size: 24px; cursor: pointer;"></span>
-                                <span class="ms-1" style="font-size: 14px;">{{i.reposts}}</span>
+                                <span class="bi bi-send share-icon" style="font-size: 24px; cursor: pointer;"></span>
                             </div>
                         </div>
                         <!-- Bookmark -->

--- a/software/DICE/DICE/T_Item_Insta.html
+++ b/software/DICE/DICE/T_Item_Insta.html
@@ -24,10 +24,12 @@
                 </div>
 
                 <!-- Post Image -->
-                <div class="promoted-content spons-post position-relative">
-                    <a href="{{i.target}}" target="_blank" style="text-decoration: none; cursor: pointer;">
-                        <img src="{{i.media}}" class="w-100 img-fluid mt-2" style="object-fit: cover;" alt="{{i.alt_text}}">
-                    </a>
+                <div class="insta-post-media position-relative mt-2">
+                    <div class="promoted-content spons-post">
+                        <a href="{{i.target}}" target="_blank" style="text-decoration: none; cursor: pointer;">
+                            <img src="{{i.media}}" class="w-100 img-fluid" style="object-fit: cover;" alt="{{i.alt_text}}">
+                        </a>
+                    </div>
                 </div>
 
                 <!-- CTA Button -->
@@ -119,7 +121,9 @@
                 </div>
 
                 <!-- Post Image -->
-                <img src="{{i.media}}" class="w-100 img-fluid mt-2" style="object-fit: cover;" alt="{{i.alt_text}}">
+                <div class="insta-post-media position-relative mt-2">
+                    <img src="{{i.media}}" class="w-100 img-fluid" style="object-fit: cover;" alt="{{i.alt_text}}">
+                </div>
 
                 <!-- Post Actions -->
                 <div class="p-2">

--- a/software/DICE/DICE/T_Item_Insta.html
+++ b/software/DICE/DICE/T_Item_Insta.html
@@ -24,10 +24,12 @@
                 </div>
 
                 <!-- Post Image -->
-                <div class="promoted-content spons-post position-relative">
-                    <a href="{{i.target}}" target="_blank" style="text-decoration: none; cursor: pointer;">
-                        <img src="{{i.media}}" class="w-100 img-fluid mt-2" style="object-fit: cover;" alt="{{i.alt_text}}">
-                    </a>
+                <div class="insta-post-media position-relative mt-2">
+                    <div class="promoted-content spons-post">
+                        <a href="{{i.target}}" target="_blank" style="text-decoration: none; cursor: pointer;">
+                            <img src="{{i.media}}" class="w-100 img-fluid" style="object-fit: cover;" alt="{{i.alt_text}}">
+                        </a>
+                    </div>
                 </div>
 
                 <!-- CTA Button -->
@@ -108,7 +110,9 @@
                 </div>
 
                 <!-- Post Image -->
-                <img src="{{i.media}}" class="w-100 img-fluid mt-2" style="object-fit: cover;" alt="{{i.alt_text}}">
+                <div class="insta-post-media position-relative mt-2">
+                    <img src="{{i.media}}" class="w-100 img-fluid" style="object-fit: cover;" alt="{{i.alt_text}}">
+                </div>
 
                 <!-- Post Actions -->
                 <div class="p-2">

--- a/software/DICE/DICE/T_Item_Linkedin.html
+++ b/software/DICE/DICE/T_Item_Linkedin.html
@@ -41,7 +41,7 @@
                         <span class="like-count ms-1">{{i.likes}}</span>
                     </span>
                     <span class="text-muted">
-                        <span class="reply-count">{{i.replies}}</span> comments &middot; {{i.reposts}} reposts
+                        <span class="reply-count">{{i.replies}}</span> comments &middot; <span class="repost-count">{{i.reposts}}</span> reposts
                     </span>
                 </div>
             </div>
@@ -59,12 +59,13 @@
                     <i class="bi bi-chat-dots reply-icon" id="reply_icon_{{i.doc_id}}" style="font-size: 20px;"></i>
                     <span style="font-size: 12px; font-weight: 600;">Comment</span>
                 </div>
-                <div class="d-flex flex-column align-items-center py-2 px-3 rounded" style="cursor: pointer;">
-                    <i class="bi bi-arrow-left-right" style="font-size: 20px;"></i>
+                <div class="repost-button d-flex flex-column align-items-center py-2 px-3 rounded" id="repost_button_{{i.doc_id}}" style="cursor: pointer;">
+                    <i class="bi bi-arrow-left-right repost-icon" style="font-size: 20px;"></i>
+                    <span class="repost-count d-none">{{i.reposts}}</span>
                     <span style="font-size: 12px; font-weight: 600;">Repost</span>
                 </div>
-                <div class="d-flex flex-column align-items-center py-2 px-3 rounded" style="cursor: pointer;">
-                    <i class="bi bi-send-fill" style="font-size: 20px;"></i>
+                <div class="share-button d-flex flex-column align-items-center py-2 px-3 rounded" style="cursor: pointer;">
+                    <i class="bi bi-send-fill share-icon" style="font-size: 20px;"></i>
                     <span style="font-size: 12px; font-weight: 600;">Send</span>
                 </div>
             </div>
@@ -110,7 +111,7 @@
                         <span class="like-count ms-1">{{i.likes}}</span>
                     </span>
                     <span class="text-muted">
-                        <span class="reply-count">{{i.replies}}</span> comments &middot; {{i.reposts}} reposts
+                        <span class="reply-count">{{i.replies}}</span> comments &middot; <span class="repost-count">{{i.reposts}}</span> reposts
                     </span>
                 </div>
             </div>
@@ -128,12 +129,13 @@
                     <i class="bi bi-chat-dots reply-icon" id="reply_icon_{{i.doc_id}}" style="font-size: 20px;"></i>
                     <span style="font-size: 12px; font-weight: 600;">Comment</span>
                 </div>
-                <div class="d-flex flex-column align-items-center py-2 px-3 rounded" style="cursor: pointer;">
-                    <i class="bi bi-arrow-left-right" style="font-size: 20px;"></i>
+                <div class="repost-button d-flex flex-column align-items-center py-2 px-3 rounded" id="repost_button_{{i.doc_id}}" style="cursor: pointer;">
+                    <i class="bi bi-arrow-left-right repost-icon" style="font-size: 20px;"></i>
+                    <span class="repost-count d-none">{{i.reposts}}</span>
                     <span style="font-size: 12px; font-weight: 600;">Repost</span>
                 </div>
-                <div class="d-flex flex-column align-items-center py-2 px-3 rounded" style="cursor: pointer;">
-                    <i class="bi bi-send-fill" style="font-size: 20px;"></i>
+                <div class="share-button d-flex flex-column align-items-center py-2 px-3 rounded" style="cursor: pointer;">
+                    <i class="bi bi-send-fill share-icon" style="font-size: 20px;"></i>
                     <span style="font-size: 12px; font-weight: 600;">Send</span>
                 </div>
             </div>

--- a/software/DICE/DICE/T_Item_Twitter.html
+++ b/software/DICE/DICE/T_Item_Twitter.html
@@ -56,7 +56,7 @@
                         <span class="reply-count text-secondary" id="reply_count_{{i.doc_id}}">{{i.replies}}</span>
                     </div>
                     <!-- Repost -->
-                    <div class="repost-button col">
+                    <div class="repost-button col" id="repost_button_{{i.doc_id}}">
                         <span class="bi bi-arrow-repeat text-secondary repost-icon" style="cursor: pointer">️</span>
                         <span class="repost-count text-secondary">{{i.reposts}}</span>
                     </div>
@@ -147,7 +147,7 @@
                 <span class="reply-count text-secondary" id="reply_count_{{i.doc_id}}">{{i.replies}}</span>
             </div>
             <!-- Repost -->
-            <div class="repost-button col ps-5">
+            <div class="repost-button col ps-5" id="repost_button_{{i.doc_id}}">
                 <span class="bi bi-arrow-repeat text-secondary repost-icon" style="cursor: pointer">️</span>
                 <span class="repost-count text-secondary">{{i.reposts}}</span>
             </div>
@@ -244,7 +244,7 @@
                         <span class="reply-count text-secondary" id="reply_count_{{i.doc_id}}">{{i.replies}}</span>
                     </div>
                     <!-- Repost -->
-                    <div class="repost-button col">
+                    <div class="repost-button col" id="repost_button_{{i.doc_id}}">
                         <span class="bi bi-arrow-repeat text-secondary repost-icon" style="cursor: pointer">️</span>
                         <span class="repost-count text-secondary">{{i.reposts}}</span>
                     </div>

--- a/software/DICE/DICE/__init__.py
+++ b/software/DICE/DICE/__init__.py
@@ -50,6 +50,8 @@ class Player(BasePlayer):
     rowheight_data = models.LongStringField(doc='tracks the time feed items were visible in a participants viewport.')
     likes_data = models.LongStringField(doc='tracks likes.', blank=True)
     replies_data = models.LongStringField(doc='tracks replies.', blank=True)
+    # New sessions require `otree resetdb` after adding this field.
+    reposts_data = models.LongStringField(doc='tracks reposts.', blank=True)
     promoted_post_clicks = models.LongStringField(doc='tracks the clicks on sponsored posts.', blank=True)
 
 
@@ -286,7 +288,7 @@ class C_Feed(Page):
 
     @staticmethod
     def get_form_fields(player: Player):
-        fields =  ['likes_data', 'replies_data', 'promoted_post_clicks', 'touch_capability', 'device_type', 'screen_resolution']
+        fields =  ['likes_data', 'replies_data', 'reposts_data', 'promoted_post_clicks', 'touch_capability', 'device_type', 'screen_resolution']
 
         if not player.session.config['topics'] & player.session.config['show_cta']:
             more_fields =  ['scroll_sequence', 'viewport_data', "rowheight_data"] # , 'cta']
@@ -369,9 +371,9 @@ page_sequence = [A_Intro,
 def custom_export(players):
     # header row
     yield ['session', 'participant_code', 'participant_label', 'participant_in_session', 'condition', 'item_sequence',
-           'scroll_sequence', 'item_dwell_time', 'likes', 'replies']
+           'scroll_sequence', 'item_dwell_time', 'likes', 'replies', 'reposts']
     for p in players:
         participant = p.participant
         session = p.session
         yield [session.code, participant.code, participant.label, p.id_in_group, p.feed_condition, p.sequence,
-               p.scroll_sequence, p.viewport_data, p.likes_data, p.replies_data]
+               p.scroll_sequence, p.viewport_data, p.likes_data, p.replies_data, p.reposts_data]

--- a/software/DICE/DICE/static/css/preloader_insta.css
+++ b/software/DICE/DICE/static/css/preloader_insta.css
@@ -99,3 +99,28 @@
     right: 0;
     border: 2px solid white;
 }
+
+.insta-repost-icon {
+    position: relative;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.insta-repost-icon svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 24px;
+    height: 24px;
+}
+
+.insta-repost-icon .repost-icon-check.d-none,
+.insta-repost-icon .repost-icon-default.d-none {
+    display: none !important;
+}
+
+.repost-button {
+    cursor: pointer;
+}

--- a/software/DICE/DICE/static/css/preloader_insta.css
+++ b/software/DICE/DICE/static/css/preloader_insta.css
@@ -99,3 +99,65 @@
     right: 0;
     border: 2px solid white;
 }
+
+/* Double-tap like overlay on post media */
+.insta-post-media {
+    overflow: hidden;
+}
+
+.insta-double-tap-heart {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.insta-double-tap-heart-icon {
+    font-size: 96px;
+    line-height: 1;
+    color: #ffffff;
+    opacity: 0;
+    transform: scale(0);
+    filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.6)) drop-shadow(0 4px 20px rgba(0, 0, 0, 0.45));
+    will-change: transform, opacity;
+}
+
+.insta-double-tap-heart.is-visible .insta-double-tap-heart-icon {
+    animation: insta-heart-pop 1s ease-out forwards;
+}
+
+@keyframes insta-heart-pop {
+    0% {
+        opacity: 0;
+        transform: scale(0);
+    }
+    12% {
+        opacity: 1;
+        transform: scale(1.25);
+    }
+    24% {
+        transform: scale(0.95);
+    }
+    36% {
+        transform: scale(1);
+    }
+    70% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .insta-double-tap-heart.is-visible .insta-double-tap-heart-icon {
+        animation: none;
+        opacity: 1;
+        transform: scale(1);
+    }
+}

--- a/software/DICE/DICE/static/css/preloader_insta.css
+++ b/software/DICE/DICE/static/css/preloader_insta.css
@@ -124,3 +124,65 @@
 .repost-button {
     cursor: pointer;
 }
+
+/* Double-tap like overlay on post media */
+.insta-post-media {
+    overflow: hidden;
+}
+
+.insta-double-tap-heart {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.insta-double-tap-heart-icon {
+    font-size: 96px;
+    line-height: 1;
+    color: #ffffff;
+    opacity: 0;
+    transform: scale(0);
+    filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.6)) drop-shadow(0 4px 20px rgba(0, 0, 0, 0.45));
+    will-change: transform, opacity;
+}
+
+.insta-double-tap-heart.is-visible .insta-double-tap-heart-icon {
+    animation: insta-heart-pop 1s ease-out forwards;
+}
+
+@keyframes insta-heart-pop {
+    0% {
+        opacity: 0;
+        transform: scale(0);
+    }
+    12% {
+        opacity: 1;
+        transform: scale(1.25);
+    }
+    24% {
+        transform: scale(0.95);
+    }
+    36% {
+        transform: scale(1);
+    }
+    70% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .insta-double-tap-heart.is-visible .insta-double-tap-heart-icon {
+        animation: none;
+        opacity: 1;
+        transform: scale(1);
+    }
+}

--- a/software/DICE/DICE/static/js/insta_double_tap_like.js
+++ b/software/DICE/DICE/static/js/insta_double_tap_like.js
@@ -1,0 +1,88 @@
+console.log("Instagram double-tap like ready!");
+
+document.addEventListener('DOMContentLoaded', function () {
+    var DOUBLE_TAP_MS = 300;
+    var TAP_MOVE_THRESHOLD_PX = 20;
+    var OVERLAY_DURATION_MS = 1000;
+
+    var lastTapByMedia = new WeakMap();
+
+    function showHeartOverlay(mediaElement) {
+        var overlay = mediaElement.querySelector('.insta-double-tap-heart');
+        if (!overlay) {
+            overlay = document.createElement('span');
+            overlay.className = 'insta-double-tap-heart';
+            overlay.setAttribute('aria-hidden', 'true');
+            overlay.innerHTML = '<i class="bi bi-heart-fill insta-double-tap-heart-icon"></i>';
+            mediaElement.appendChild(overlay);
+        }
+
+        var heartIcon = overlay.querySelector('.insta-double-tap-heart-icon');
+        overlay.classList.remove('is-visible');
+        if (heartIcon) {
+            heartIcon.style.animation = 'none';
+            void heartIcon.offsetWidth;
+            heartIcon.style.animation = '';
+        }
+        void overlay.offsetWidth;
+        overlay.classList.add('is-visible');
+
+        window.setTimeout(function () {
+            overlay.classList.remove('is-visible');
+        }, OVERLAY_DURATION_MS);
+    }
+
+    function handleDoubleLike(mediaElement, event) {
+        var instaPost = mediaElement.closest('.insta-post');
+        if (!instaPost) {
+            return;
+        }
+
+        if (event) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        if (typeof window.diceLikeInstaPostMedia === 'function') {
+            window.diceLikeInstaPostMedia(instaPost);
+        }
+
+        showHeartOverlay(mediaElement);
+    }
+
+    function registerDoubleTap(mediaElement) {
+        mediaElement.addEventListener('dblclick', function (event) {
+            handleDoubleLike(mediaElement, event);
+        });
+
+        mediaElement.addEventListener('touchend', function (event) {
+            if (event.changedTouches.length !== 1) {
+                return;
+            }
+
+            var touch = event.changedTouches[0];
+            var lastTap = lastTapByMedia.get(mediaElement);
+            var now = Date.now();
+
+            if (lastTap) {
+                var timeDelta = now - lastTap.time;
+                var moveX = Math.abs(touch.clientX - lastTap.x);
+                var moveY = Math.abs(touch.clientY - lastTap.y);
+
+                if (timeDelta <= DOUBLE_TAP_MS && moveX <= TAP_MOVE_THRESHOLD_PX && moveY <= TAP_MOVE_THRESHOLD_PX) {
+                    handleDoubleLike(mediaElement, event);
+                    lastTapByMedia.delete(mediaElement);
+                    return;
+                }
+            }
+
+            lastTapByMedia.set(mediaElement, {
+                time: now,
+                x: touch.clientX,
+                y: touch.clientY
+            });
+        });
+    }
+
+    document.querySelectorAll('.insta-post .insta-post-media').forEach(registerDoubleTap);
+});

--- a/software/DICE/DICE/static/js/interactions.js
+++ b/software/DICE/DICE/static/js/interactions.js
@@ -33,39 +33,7 @@ function replyOneUp(){
 
 
 
-// REPOSTS (Frontend only)
-var repostButtons = document.querySelectorAll(".repost-button");
-
-repostButtons.forEach(function(repostButton) {
-    var repostCount = repostButton.querySelector(".repost-count");
-    var repostIcon  = repostButton.querySelector(".repost-icon");
-
-    repostButton.addEventListener("click", function() {
-        let originalText = repostCount.textContent;
-        let repostNum = parseInt(originalText.replace(/[^0-9]/g, '')); // Remove non-numeric characters
-
-        if (repostButton.classList.contains("reposted")) {
-            repostButton.classList.remove("reposted");
-            if (!originalText.includes('K') && !originalText.includes('M')) {
-                repostNum--; // Decrement if no 'K' or 'M'
-                repostCount.textContent = repostNum.toString();
-            }
-            repostIcon.className="bi bi-arrow-repeat text-secondary repost-icon";
-            repostIcon.removeAttribute("style");
-        } else {
-            repostButton.classList.add("reposted");
-            if (!originalText.includes('K') && !originalText.includes('M')) {
-                repostNum++; // Increment if no 'K' or 'M'
-                repostCount.textContent = repostNum.toString();
-            }
-            repostIcon.className="bi bi-arrow-repeat text-primary repost-icon";
-            repostIcon.style="font-weight: bold"; // Adjust style to indicate active state
-        }
-    });
-});
-
-
-// LIKES
+// SHARES (Frontend only)
 /*var likeButtons = document.querySelectorAll(".like-button");
 
 likeButtons.forEach(function(likeButton) {
@@ -109,11 +77,19 @@ shareButtons.forEach(function(shareButton) {
     shareButton.addEventListener("click", function() {
       if (shareButton.classList.contains("shared")) {
         shareButton.classList.remove("shared");
-        shareIcon.className="bi bi-upload text-secondary share-icon";
+        if (shareIcon.classList.contains('bi-send') || shareIcon.classList.contains('bi-send-fill')) {
+            shareIcon.className="bi bi-send text-secondary share-icon";
+        } else {
+            shareIcon.className="bi bi-upload text-secondary share-icon";
+        }
         shareIcon.removeAttribute("style")
     } else {
         shareButton.classList.add("shared");
-        shareIcon.className="bi bi-upload text-primary share-icon";
+        if (shareIcon.classList.contains('bi-send') || shareIcon.classList.contains('bi-send-fill')) {
+            shareIcon.className="bi bi-send text-primary share-icon";
+        } else {
+            shareIcon.className="bi bi-upload text-primary share-icon";
+        }
         shareIcon.style="-webkit-text-stroke: 0.5px"
     }
 });

--- a/software/DICE/DICE/static/js/like_button.js
+++ b/software/DICE/DICE/static/js/like_button.js
@@ -3,7 +3,8 @@ console.log("Reactions (likes, replies, and promoted content clicks) ready!");
 document.addEventListener('DOMContentLoaded', function() {
     console.log("Document is ready!");
 
-    function toggleLike(button) {
+    function toggleLike(button, options) {
+        options = options || {};
         const icon = button.querySelector('.like-icon');
         const likeCountSpan = button.querySelector('.like-count');
         let originalText = likeCountSpan.textContent;
@@ -12,6 +13,13 @@ document.addEventListener('DOMContentLoaded', function() {
         // Detect icon type: heart (Twitter/Instagram) or thumbs-up (LinkedIn)
         let isHeart = icon.classList.contains('bi-heart') || icon.classList.contains('bi-heart-fill');
         let isThumbs = icon.classList.contains('bi-hand-thumbs-up') || icon.classList.contains('bi-hand-thumbs-up-fill');
+
+        if (options.onlyLike) {
+            let alreadyLiked = icon.classList.contains('bi-heart-fill') || icon.classList.contains('bi-hand-thumbs-up-fill');
+            if (alreadyLiked) {
+                return false;
+            }
+        }
 
         if (isHeart) {
             if (icon.classList.contains('bi-heart')) {
@@ -60,7 +68,20 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         console.log("Like toggled for button:", button.id, "; New count:", newText);
+        return true;
     }
+
+    window.diceApplyLike = function (likeButton, options) {
+        return toggleLike(likeButton, options);
+    };
+
+    window.diceLikeInstaPostMedia = function (instaPost) {
+        const likeButton = instaPost.querySelector('.like-button');
+        if (!likeButton) {
+            return false;
+        }
+        return toggleLike(likeButton, { onlyLike: true });
+    };
 
     document.querySelectorAll('.like-button').forEach(button => {
         button.addEventListener('click', function() {

--- a/software/DICE/DICE/static/js/repost_button.js
+++ b/software/DICE/DICE/static/js/repost_button.js
@@ -1,0 +1,266 @@
+console.log("Reposts ready!");
+
+const INSTA_FIRST_REPOST_KEY = 'dice_insta_first_repost_shown';
+let lastInstagramRepostedButton = null;
+
+function getDocIdFromRepostButton(button) {
+    const buttonId = button.getAttribute('id');
+    if (buttonId && buttonId.startsWith('repost_button_')) {
+        return parseInt(buttonId.replace('repost_button_', ''), 10);
+    }
+
+    const post = button.closest('.insta-post')
+        || button.closest('.tweet-content')
+        || button.closest('.linkedin-post');
+    if (post && post.id) {
+        if (post.id.startsWith('tweet_')) {
+            return parseInt(post.id.replace('tweet_', ''), 10);
+        }
+        return parseInt(post.id, 10);
+    }
+    return null;
+}
+
+function updateRepostCountDisplay(button, newText) {
+    const repostCountSpan = button.querySelector('.repost-count');
+    if (repostCountSpan) {
+        repostCountSpan.textContent = newText;
+    }
+
+    const post = button.closest('.insta-post')
+        || button.closest('.tweet-content')
+        || button.closest('.linkedin-post');
+    if (post) {
+        post.querySelectorAll('.repost-count').forEach(function(span) {
+            if (span !== repostCountSpan) {
+                span.textContent = newText;
+            }
+        });
+    }
+}
+
+function setInstagramRepostIconActive(button, isActive) {
+    const instaIcon = button.querySelector('.insta-repost-icon');
+    if (!instaIcon) {
+        return false;
+    }
+
+    const defaultSvg = instaIcon.querySelector('.repost-icon-default');
+    const checkSvg = instaIcon.querySelector('.repost-icon-check');
+    if (!defaultSvg || !checkSvg) {
+        return false;
+    }
+
+    if (isActive) {
+        defaultSvg.classList.add('d-none');
+        checkSvg.classList.remove('d-none');
+    } else {
+        defaultSvg.classList.remove('d-none');
+        checkSvg.classList.add('d-none');
+    }
+    return true;
+}
+
+function setRepostIconActive(button, isActive) {
+    if (setInstagramRepostIconActive(button, isActive)) {
+        return;
+    }
+
+    const icon = button.querySelector('.repost-icon');
+    if (!icon) {
+        return;
+    }
+
+    const isLinkedIn = icon.classList.contains('bi-arrow-left-right');
+
+    if (isActive) {
+        icon.classList.add('repost-active');
+        if (isLinkedIn) {
+            icon.classList.add('text-primary');
+        } else {
+            icon.className = 'bi bi-arrow-repeat text-primary repost-icon';
+            icon.style.fontWeight = 'bold';
+        }
+    } else {
+        icon.classList.remove('repost-active', 'text-primary');
+        icon.style.fontWeight = '';
+        if (isLinkedIn) {
+            icon.className = 'bi bi-arrow-left-right repost-icon';
+            icon.style.fontSize = '20px';
+        } else {
+            icon.className = 'bi bi-arrow-repeat text-secondary repost-icon';
+            icon.removeAttribute('style');
+        }
+    }
+}
+
+function toggleRepost(button) {
+    const repostCount = button.querySelector('.repost-count');
+    const originalText = repostCount ? repostCount.textContent : '0';
+    let repostNum = parseInt(originalText.replace(/[^0-9]/g, ''), 10) || 0;
+    const hasFormattedCount = originalText.includes('K') || originalText.includes('M');
+
+    if (button.classList.contains('reposted')) {
+        button.classList.remove('reposted');
+        if (!hasFormattedCount && repostCount) {
+            repostNum -= 1;
+            updateRepostCountDisplay(button, repostNum.toString());
+        }
+        setRepostIconActive(button, false);
+    } else {
+        button.classList.add('reposted');
+        if (!hasFormattedCount && repostCount) {
+            repostNum += 1;
+            updateRepostCountDisplay(button, repostNum.toString());
+        }
+        setRepostIconActive(button, true);
+    }
+
+    console.log("toggleRepost - button.id");
+    console.log(button.id);
+}
+
+function undoRepost(button) {
+    if (!button || !button.classList.contains('reposted')) {
+        return;
+    }
+
+    toggleRepost(button);
+}
+
+function showFirstInstagramRepostModal() {
+    if (sessionStorage.getItem(INSTA_FIRST_REPOST_KEY)) {
+        return;
+    }
+
+    sessionStorage.setItem(INSTA_FIRST_REPOST_KEY, 'true');
+    const firstRepostModal = document.getElementById('firstRepostModal');
+    if (!firstRepostModal || typeof bootstrap === 'undefined') {
+        return;
+    }
+
+    const confirmModal = new bootstrap.Modal(firstRepostModal);
+    confirmModal.show();
+}
+
+function handleInstagramRepostClick(button) {
+    if (button.classList.contains('reposted')) {
+        undoRepost(button);
+        lastInstagramRepostedButton = null;
+        return;
+    }
+
+    toggleRepost(button);
+    lastInstagramRepostedButton = button;
+    showFirstInstagramRepostModal();
+}
+
+function handleStandardRepostClick(button) {
+    toggleRepost(button);
+}
+
+function collectReposts() {
+    const repostsData = [];
+    document.querySelectorAll('.repost-button').forEach(function(button) {
+        const docId = getDocIdFromRepostButton(button);
+        if (docId === null) {
+            return;
+        }
+
+        repostsData.push({
+            doc_id: docId,
+            reposted: button.classList.contains('reposted'),
+            repost_note: ''
+        });
+    });
+
+    console.log("collectReposts - repostsData");
+    console.log(repostsData);
+    return repostsData;
+}
+
+function serializeRepostsToField() {
+    const repostsField = document.getElementById('reposts_data');
+    if (!repostsField) {
+        return;
+    }
+
+    const repostsData = collectReposts();
+    repostsField.value = JSON.stringify(repostsData);
+
+    console.log("serializeRepostsToField - repostsData");
+    console.log(repostsData);
+}
+
+function initRepostSubmitHandlers() {
+    const submitButtonIds = ['submitButtonTop', 'submitButtonBottom', 'submitButton'];
+
+    submitButtonIds.forEach(function(buttonId) {
+        const submitButton = document.getElementById(buttonId);
+        if (!submitButton || submitButton.dataset.repostSubmitBound === 'true') {
+            return;
+        }
+
+        submitButton.dataset.repostSubmitBound = 'true';
+        submitButton.addEventListener('click', function() {
+            serializeRepostsToField();
+        });
+    });
+}
+
+function initRepostButtons() {
+    const instaFeed = document.getElementById('insta_feed');
+
+    if (instaFeed && !instaFeed.dataset.repostBound) {
+        instaFeed.dataset.repostBound = 'true';
+        instaFeed.addEventListener('click', function(event) {
+            const button = event.target.closest('.repost-button');
+            if (!button || !instaFeed.contains(button)) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            handleInstagramRepostClick(button);
+        });
+
+        const undoButton = document.getElementById('firstRepostUndo');
+        if (undoButton && !undoButton.dataset.repostBound) {
+            undoButton.dataset.repostBound = 'true';
+            undoButton.addEventListener('click', function() {
+                if (lastInstagramRepostedButton) {
+                    undoRepost(lastInstagramRepostedButton);
+                    lastInstagramRepostedButton = null;
+                }
+            });
+        }
+
+        console.log("initRepostButtons - instagram feed bound");
+        console.log(instaFeed);
+        return;
+    }
+
+    document.querySelectorAll('.repost-button').forEach(function(button) {
+        if (button.dataset.repostBound === 'true') {
+            return;
+        }
+        button.dataset.repostBound = 'true';
+        button.addEventListener('click', function(event) {
+            event.preventDefault();
+            handleStandardRepostClick(button);
+        });
+    });
+}
+
+function runWhenDocumentReady(callback) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback);
+    } else {
+        callback();
+    }
+}
+
+runWhenDocumentReady(function() {
+    initRepostButtons();
+    initRepostSubmitHandlers();
+});


### PR DESCRIPTION
## Summary
  - Add end-to-end repost tracking: new `Player.reposts_data` field, hidden form inputs on all feed templates, and
  export column in `custom_export`.
  - Introduce `repost_button.js` to handle repost toggling, Instagram first-repost modal/undo, and submit
  serialization for `reposts_data` (decoupled from `like_button.js`).
  - Update feed item templates with repost buttons and platform-specific styling (Instagram SVG icons, LinkedIn
  stats sync, Twitter/Generic button IDs).
  - Fix review follow-ups: add missing `reposts_data` on Stories/Mass Media feeds, remove unused repost stub/assets,
  and document `otree resetdb` requirement.
  ## Deployment note
  Run `otree resetdb` before testing or deploying — `reposts_data` is a new Player column.
  ## Test plan
  - [ ] Run `otree resetdb` locally
  - [ ] **Instagram** — repost a post, confirm first-repost modal appears; test Undo and OK; submit and verify
  `reposts_data` JSON
  - [ ] **Twitter / LinkedIn / Generic** — toggle repost, confirm icon/count updates; submit and verify data saved
  - [ ] **Stories / Mass Media** — submit without console errors (reposts should serialize as `[]`)
  - [ ] Export participant data and confirm `reposts` column is present
  - [ ] Confirm share button still works on Instagram (`bi-send`) and Twitter (`bi-upload`)